### PR TITLE
Bump logback.version from 1.4.0 to 1.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
         <maven.compiler.target>11</maven.compiler.target>
 
         <slf4j.version>2.0.0</slf4j.version>
-        <logback.version>1.4.0</logback.version>
+        <logback.version>1.4.4</logback.version>
         <license-maven-plugin.version>4.2.rc3</license-maven-plugin.version>
         <commons.lang3>3.12.0</commons.lang3>
         <jacoco.version>0.8.8</jacoco.version>


### PR DESCRIPTION
Bumps `logback.version` from 1.4.0 to 1.4.4.

Updates `logback-core` from 1.4.0 to 1.4.4
- [Release notes](https://github.com/qos-ch/logback/releases)
- [Commits](https://github.com/qos-ch/logback/compare/v_1.4.0...v_1.4.4)

Updates `logback-classic` from 1.4.0 to 1.4.4
- [Release notes](https://github.com/qos-ch/logback/releases)
- [Commits](https://github.com/qos-ch/logback/compare/v_1.4.0...v_1.4.4)

---
updated-dependencies:
- dependency-name: ch.qos.logback:logback-core dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: ch.qos.logback:logback-classic dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>