### PR TITLE
Bump dirigible.version from 6.3.25 to 6.3.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
     <properties>
         <project.title>codbex chronos</project.title>
 
-        <dirigible.version>6.3.25</dirigible.version>
+        <dirigible.version>6.3.26</dirigible.version>
 
         <java.version>11</java.version>
 


### PR DESCRIPTION
Bumps `dirigible.version` from 6.3.25 to 6.3.26.

Updates `dirigible-server-all` from 6.3.25 to 6.3.26

Updates `dirigible-server-keycloak-all` from 6.3.25 to 6.3.26

---
updated-dependencies:
- dependency-name: org.eclipse.dirigible:dirigible-server-all dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.eclipse.dirigible:dirigible-server-keycloak-all dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>